### PR TITLE
Added guard against non-int indices

### DIFF
--- a/match.py
+++ b/match.py
@@ -116,6 +116,9 @@ def cut(cuts, audio, sensor, outdir, verbose):
 
     for n, i, o in cuts:
 
+        i = int(i)
+        o = int(o)
+
         d_audio = audio[i:o]
 
         i64 = i / 64


### PR DESCRIPTION
For some reason the `i` and `o` parameters in `cuts` were `floats` and not `ints`, so I added a cast to correct this. This was causing `match_audio.sh` to fail.
